### PR TITLE
Removed macros for desktop behaviour

### DIFF
--- a/config/da-includes.dtsi
+++ b/config/da-includes.dtsi
@@ -87,27 +87,5 @@
               ;
       };
         
-      mac_exp: mac_exp {
-          label = "mac_exp";
-          compatible = "zmk,behavior-macro";
-          #binding-cells = <0>;
-          bindings
-              = <&macro_press &kp LCTRL>
-              , <&macro_tap &kp DOWN>
-              , <&macro_release &kp LCTRL>
-              ;
-      };
-
-      mac_mc: mac_mc {
-          label = "mac_mc";
-          compatible = "zmk,behavior-macro";
-          #binding-cells = <0>;
-          bindings
-              = <&macro_press &kp LCTRL>
-              , <&macro_tap &kp UP>
-              , <&macro_release &kp LCTRL>
-              ;
-      };
-
   };
 };

--- a/config/splitkb_aurora_corne.keymap
+++ b/config/splitkb_aurora_corne.keymap
@@ -53,7 +53,7 @@
 //                             +---------+---------+---------+    +---------+---------+---------+
                    layer_above {
                           bindings = <
-    &mac_mc  &mac_exp  &trans    &e_gr   &e_ac      &trans        &trans     &u_gr      &i_gr     &o_gr     &kp C_VOL_UP &kp BSPC
+    &trans   &trans    &trans    &e_gr   &e_ac      &trans        &trans     &u_gr      &i_gr     &o_gr     &kp C_VOL_UP &kp BSPC
     &kp F1   &a_gr     &kp F2    &kp F3  &kp F4     &kp F5        &kp LEFT   &kp DOWN   &kp UP    &kp RIGHT &kp C_VOL_DN  &bt BT_CLR
     &trans   &kp F6    &kp F7    &kp F8  &kp F9     &kp F10       &kp C_PP   &kp C_PREV &kp C_NEXT&trans    &kp C_MUTE    &bt BT_NXT
                                  &trans  &trans     &trans        &trans     &trans     &trans


### PR DESCRIPTION
Exposé shortcuts are now provided with a repeated F3 key in the layer with symbols, and are removed from the control layer